### PR TITLE
Fixed issues related to JSON decode, enum decode, duplicated `CareerType` entries and other minor fixes

### DIFF
--- a/asagiri/Enums/ApplicationStatus.swift
+++ b/asagiri/Enums/ApplicationStatus.swift
@@ -26,12 +26,12 @@ enum ApplicationStatus : Codable, Hashable, Identifiable {
         return self
     }
     
-    case not_started
+    case notStarted
     case preparation
     case applied
     case oa
-    case phone_screen
-    case technical_test
+    case phoneScreen
+    case technicalTest
     case interview(round: Int)
     case rejected
     case offer
@@ -41,12 +41,12 @@ enum ApplicationStatus : Codable, Hashable, Identifiable {
     
     func color() -> Color {
         return switch self {
-        case .not_started: .black
+        case .notStarted: .black
         case .preparation: .black
         case .applied: .yellow
         case .oa: .purple
-        case .technical_test: .indigo
-        case .phone_screen: .orange
+        case .technicalTest: .indigo
+        case .phoneScreen: .orange
         case .interview(_): .orange
         case .rejected: .gray
         case .offer: .green
@@ -58,12 +58,12 @@ enum ApplicationStatus : Codable, Hashable, Identifiable {
     
     func possibleNexts() -> [ApplicationStatus] {
         return switch self {
-        case .not_started: [.preparation, .applied]
+        case .notStarted: [.preparation, .applied]
         case .preparation: [.applied]
-        case .applied: [.oa, .phone_screen, .interview(round: 1), .rejected, .offer]
-        case .oa: [.phone_screen, .technical_test, .interview(round: 1), .rejected]
-        case .phone_screen: [.technical_test, .interview(round: 1), .rejected]
-        case .technical_test: [.interview(round: 1), .rejected]
+        case .applied: [.oa, .phoneScreen, .interview(round: 1), .rejected, .offer]
+        case .oa: [.phoneScreen, .technicalTest, .interview(round: 1), .rejected]
+        case .phoneScreen: [.technicalTest, .interview(round: 1), .rejected]
+        case .technicalTest: [.interview(round: 1), .rejected]
         case .interview(let round): [.interview(round: round + 1), .rejected, .offer]
         case .rejected: []
         case .offer: [.rejected, .ghost]
@@ -78,102 +78,17 @@ enum ApplicationStatus : Codable, Hashable, Identifiable {
         default: true
         }
     }
-    
-//     Seems that the enums with SwiftData are broken in deserializing JSON files
-//     as mentioned here: https://stackoverflow.com/questions/76645050/error-trying-to-use-swiftdata-property-based-on-an-enum-with-an-associated-value
-//     A walkthrough for the current Xcode and iOS versions
-    
-//     The following codes will not work as creating a data and accessing it will throw an error of type:
-//     > Could not cast value of type '() -> ()' (0x103047210) to 'Swift.String' (0x1f482a7c0) - if we attempt to decode the enum
-//     > The code snippet has two arms regarding whether the case has an associated value
-//     > But the container.allKeys will always have only one element, like `CodingKeys(stringValue: "preparation", intValue: nil)`
-//     > And the code will fail
-    
-//    enum CodingKeys : CodingKey {
-//        case not_started, preparation, applied, oa, phone_screen, technical_test, interview, rejected, offer, ghost, archived
-//        case interview__arg0
-//    }
-//    
-//    init(from decoder: Decoder) throws {
-//        do {
-//            let container = try decoder.container(keyedBy: CodingKeys.self)
-//            var allKeys = ArraySlice(container.allKeys)
-//            if let oneKey = allKeys.popFirst(), allKeys.isEmpty {
-//                // There is only a key for the associated value cases
-//                if container.contains(.interview) {
-//                    let sub = try container.nestedContainer(keyedBy: CodingKeys.self, forKey: oneKey)
-//                    let val = try sub.decode(Int.self, forKey: .interview__arg0)
-//                    self = .interview(round: val)
-//                } else {
-//                    // Only reached for the cases with no associated value
-//                    let container = try decoder.singleValueContainer()
-//                    let val = try container.decode(String.self)
-//                    switch val {
-//                    case "not_started": self = .not_started
-//                    case "preparation": self = .preparation
-//                    case "applied": self = .applied
-//                    case "oa": self = .oa
-//                    case "technical_test": self = .technical_test
-//                    case "phone_screen": self = .phone_screen
-//                    case "rejected": self = .rejected
-//                    case "offer": self = .offer
-//                    case "ghost": self = .ghost
-//                    case "archived": self = .archived
-//                    default:
-//                        throw DecodingError.typeMismatch(ApplicationStatus.self, DecodingError.Context.init(codingPath: container.codingPath, debugDescription: "Custom Error: Unexpected associated value of '\(val)'", underlyingError: nil))
-//                    }
-//                }
-//            } else {
-//                throw DecodingError.typeMismatch(ApplicationStatus.self, DecodingError.Context.init(codingPath: container.codingPath, debugDescription: "Custom Error: Empty", underlyingError: nil))
-//            }
-//        } catch {
-//            print(error)
-//            throw error
-//        }
-//    }
-//    
-//    func encode(to encoder: Encoder) throws {
-//        print ("encode \(self)")
-//        var container = encoder.container(keyedBy: CodingKeys.self)
-//        switch self {
-//        case .not_started:
-//            try! container.encode("not_started", forKey: .not_started)
-//        case .preparation:
-//            try! container.encode("preparation", forKey: .preparation)
-//        case .applied:
-//            try! container.encode("applied", forKey: .applied)
-//        case .oa:
-//            try! container.encode("oa", forKey: .oa)
-//        case .technical_test:
-//            try! container.encode("technical_test", forKey: .technical_test)
-//        case .phone_screen:
-//            try! container.encode("phone_screen", forKey: .phone_screen)
-//        case .interview(let val):
-//            try! container.encode(val, forKey: .interview)
-//        case .rejected:
-//            try! container.encode("rejected", forKey: .rejected)
-//        case .offer:
-//            try! container.encode("offer", forKey: .offer)
-//        case .ghost:
-//            try! container.encode("ghost", forKey: .ghost)
-//        case .archived:
-//            try! container.encode("archived", forKey: .archived)
-//        }
-//    }
 }
-
-// must conform `Codable` protocol otherwise compiler will yell
-//   "No exact matches in call to instance method 'getValue'" for usage in models
 
 extension ApplicationStatus : CustomStringConvertible {
     var description: String {
         return switch self {
-            case .not_started: "Not Started"
+            case .notStarted: "Not Started"
             case .preparation: "Preparation"
             case .applied: "Applied"
             case .oa: "OA"
-            case .technical_test: "Technical Test"
-            case .phone_screen: "Phone Screen"
+            case .technicalTest: "Technical Test"
+            case .phoneScreen: "Phone Screen"
             case .interview(let round): "Int. round \(round)"
             case .rejected: "Rejected"
             case .offer: "Offer"

--- a/asagiri/Models/ApplicationModel.swift
+++ b/asagiri/Models/ApplicationModel.swift
@@ -65,7 +65,7 @@ final class Application : Codable {
     
     // Boilerplates for codable conformance
     enum CodingKeys: CodingKey {
-        case /* jobDescription,*/ dateCreated, resume, cover, events
+        case dateCreated, resume, cover, events
     }
     
     required init(from decoder: Decoder) throws {
@@ -73,23 +73,16 @@ final class Application : Codable {
             fatalError()
         }
         let container = try decoder.container(keyedBy: CodingKeys.self)
-//        self.jobDescription = try? container.decode(JobDescription?.self, forKey: .jobDescription)
         self.resume = try? container.decode(Resume?.self, forKey: .resume)
         self.cover = try? container.decode(CoverLetter?.self, forKey: .cover)
         self.dateCreated = try container.decode(Date.self, forKey: .dateCreated)
         self.events = try container.decode([Event].self, forKey: .events)
-//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-//        try container.encode(jobDescription, forKey: .jobDescription)
-//        if resume != nil {
-            try container.encode(resume, forKey: .dateCreated)
-//        }
-//        if cover != nil {
-            try container.encode(cover, forKey: .cover)
-//        }
+        try container.encode(resume, forKey: .dateCreated)
+        try container.encode(cover, forKey: .cover)
         try container.encode(dateCreated, forKey: .dateCreated)
         try container.encode(events, forKey: .events)
     }

--- a/asagiri/Models/ApplicationModel.swift
+++ b/asagiri/Models/ApplicationModel.swift
@@ -38,7 +38,7 @@ final class Application : Codable {
 
     var status: ApplicationStatus  {
         get {
-            events.sorted(by: { $0.updateTime < $1.updateTime }).last?.type ?? .not_started
+            events.sorted(by: { $0.updateTime < $1.updateTime }).last?.type ?? .notStarted
         }
     }
     

--- a/asagiri/Models/ApplicationModel.swift
+++ b/asagiri/Models/ApplicationModel.swift
@@ -22,11 +22,14 @@ import SwiftData
 
 @Model
 final class Application : Codable {
-
+    
+    @Relationship
     var jobDescription: JobDescription? = nil
 
+    @Relationship
     var resume: Resume? = nil
 
+    @Relationship
     var cover: CoverLetter? = nil
 
     var dateCreated: Date

--- a/asagiri/Models/ApplicationModel.swift
+++ b/asagiri/Models/ApplicationModel.swift
@@ -65,7 +65,7 @@ final class Application : Codable {
     
     // Boilerplates for codable conformance
     enum CodingKeys: CodingKey {
-        case jobDescription, dateCreated, resume, cover, events
+        case /* jobDescription,*/ dateCreated, resume, cover, events
     }
     
     required init(from decoder: Decoder) throws {
@@ -73,19 +73,23 @@ final class Application : Codable {
             fatalError()
         }
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.jobDescription = try? container.decode(JobDescription?.self, forKey: .jobDescription)
+//        self.jobDescription = try? container.decode(JobDescription?.self, forKey: .jobDescription)
         self.resume = try? container.decode(Resume?.self, forKey: .resume)
         self.cover = try? container.decode(CoverLetter?.self, forKey: .cover)
         self.dateCreated = try container.decode(Date.self, forKey: .dateCreated)
         self.events = try container.decode([Event].self, forKey: .events)
-        context.insert(self)
+//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(jobDescription, forKey: .jobDescription)
-        try container.encode(resume, forKey: .dateCreated)
-        try container.encode(cover, forKey: .cover)
+//        try container.encode(jobDescription, forKey: .jobDescription)
+//        if resume != nil {
+            try container.encode(resume, forKey: .dateCreated)
+//        }
+//        if cover != nil {
+            try container.encode(cover, forKey: .cover)
+//        }
         try container.encode(dateCreated, forKey: .dateCreated)
         try container.encode(events, forKey: .events)
     }

--- a/asagiri/Models/CareerModels.swift
+++ b/asagiri/Models/CareerModels.swift
@@ -41,9 +41,13 @@ final class CareerType : Codable {
     }
     
     required init(from decoder: Decoder) throws {
+        guard let context = decoder.userInfo[CodingUserInfoKey(rawValue: "modelcontext")!] as? ModelContext else {
+            fatalError()
+        }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
         self.symbol = try? container.decode(String?.self, forKey: .symbol)
+//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/CareerModels.swift
+++ b/asagiri/Models/CareerModels.swift
@@ -47,7 +47,6 @@ final class CareerType : Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
         self.symbol = try? container.decode(String?.self, forKey: .symbol)
-//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/CompanyModel.swift
+++ b/asagiri/Models/CompanyModel.swift
@@ -27,6 +27,7 @@ final class Company : Codable {
     
 //    var comments: String = ""
     
+    @Relationship(deleteRule: .cascade, inverse: \JobDescription.company)
     var positions: [JobDescription] = []
     
     init(name: String, website: String) {
@@ -40,9 +41,14 @@ final class Company : Codable {
     }
     
     required init(from decoder: Decoder) throws {
+        guard let context = decoder.userInfo[CodingUserInfoKey(rawValue: "modelcontext")!] as? ModelContext else {
+            fatalError()
+        }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
         self.website = try container.decode(String.self, forKey: .website)
+        
+        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/CompanyModel.swift
+++ b/asagiri/Models/CompanyModel.swift
@@ -50,6 +50,7 @@ final class Company : Codable {
         
         self.positions = try container.decode([JobDescription].self, forKey: .positions)
         
+        // Persist data with its relationship
         context.insert(self)
     }
     

--- a/asagiri/Models/CompanyModel.swift
+++ b/asagiri/Models/CompanyModel.swift
@@ -37,7 +37,7 @@ final class Company : Codable {
     
     // Boilerplates for codable conformance
     enum CodingKeys: CodingKey {
-        case name, website
+        case name, website, positions
     }
     
     required init(from decoder: Decoder) throws {
@@ -48,6 +48,8 @@ final class Company : Codable {
         self.name = try container.decode(String.self, forKey: .name)
         self.website = try container.decode(String.self, forKey: .website)
         
+        self.positions = try container.decode([JobDescription].self, forKey: .positions)
+        
         context.insert(self)
     }
     
@@ -55,5 +57,7 @@ final class Company : Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(website, forKey: .website)
+        
+        try container.encode(positions, forKey: .positions)
     }
 }

--- a/asagiri/Models/CoverLetterModel.swift
+++ b/asagiri/Models/CoverLetterModel.swift
@@ -39,9 +39,13 @@ final class CoverLetter : Codable {
     }
     
     required init(from decoder: Decoder) throws {
+        guard let context = decoder.userInfo[CodingUserInfoKey(rawValue: "modelcontext")!] as? ModelContext else {
+            fatalError()
+        }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.content = try container.decode(String.self, forKey: .content)
         self.createTime = try container.decode(Date.self, forKey: .createTime)
+//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/CoverLetterModel.swift
+++ b/asagiri/Models/CoverLetterModel.swift
@@ -45,7 +45,6 @@ final class CoverLetter : Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.content = try container.decode(String.self, forKey: .content)
         self.createTime = try container.decode(Date.self, forKey: .createTime)
-//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/DescriptionModel.swift
+++ b/asagiri/Models/DescriptionModel.swift
@@ -60,7 +60,7 @@ final class JobDescription : Codable {
     
     // Boilerplates for codable conformance
     enum CodingKeys: CodingKey {
-        case title, company, application, type, intro, companyIntro, responsibilities, complementary
+        case title, application, type, intro, companyIntro, responsibilities, complementary
     }
     
     required init(from decoder: Decoder) throws {
@@ -69,7 +69,6 @@ final class JobDescription : Codable {
         }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.title = try container.decode(String.self, forKey: .title)
-        self.company = try? container.decode(Company?.self, forKey: .company)
         self.application = try? container.decode(Application?.self, forKey: .application)
         
         self.type = try? container.decode(CareerType?.self, forKey: .type)
@@ -77,21 +76,13 @@ final class JobDescription : Codable {
         self.companyIntro = try container.decode(String.self, forKey: .companyIntro)
         self.responsibilities = try container.decode(String.self, forKey: .responsibilities)
         self.complementary = try container.decode(String.self, forKey: .complementary)
-//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(title, forKey: .title)
-//        if application != nil {
-            try container.encode(application, forKey: .application)
-//        }
-//        if company != nil {
-//            try container.encode(company, forKey: .company)
-//        }
-//        if type != nil {
-            try container.encode(type, forKey: .type)
-//        }
+        try container.encode(application, forKey: .application)
+        try container.encode(type, forKey: .type)
         try container.encode(intro, forKey: .intro)
         try container.encode(companyIntro, forKey: .companyIntro)
         try container.encode(responsibilities, forKey: .responsibilities)

--- a/asagiri/Models/DescriptionModel.swift
+++ b/asagiri/Models/DescriptionModel.swift
@@ -60,7 +60,7 @@ final class JobDescription : Codable {
     
     // Boilerplates for codable conformance
     enum CodingKeys: CodingKey {
-        case title, company, type, intro, companyIntro, responsibilities, complementary
+        case title, company, application, type, intro, companyIntro, responsibilities, complementary
     }
     
     required init(from decoder: Decoder) throws {
@@ -70,7 +70,9 @@ final class JobDescription : Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.title = try container.decode(String.self, forKey: .title)
         self.company = try? container.decode(Company?.self, forKey: .company)
-        self.type = try container.decode(CareerType?.self, forKey: .type)
+        self.application = try? container.decode(Application?.self, forKey: .application)
+        
+        self.type = try? container.decode(CareerType?.self, forKey: .type)
         self.intro = try container.decode(String.self, forKey: .intro)
         self.companyIntro = try container.decode(String.self, forKey: .companyIntro)
         self.responsibilities = try container.decode(String.self, forKey: .responsibilities)
@@ -81,8 +83,15 @@ final class JobDescription : Codable {
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(title, forKey: .title)
-        try container.encode(company, forKey: .company)
-        try container.encode(type, forKey: .type)
+//        if application != nil {
+            try container.encode(application, forKey: .application)
+//        }
+//        if company != nil {
+//            try container.encode(company, forKey: .company)
+//        }
+//        if type != nil {
+            try container.encode(type, forKey: .type)
+//        }
         try container.encode(intro, forKey: .intro)
         try container.encode(companyIntro, forKey: .companyIntro)
         try container.encode(responsibilities, forKey: .responsibilities)

--- a/asagiri/Models/DescriptionModel.swift
+++ b/asagiri/Models/DescriptionModel.swift
@@ -24,6 +24,10 @@ import SwiftData
 final class JobDescription : Codable {
     var title: String
     
+    @Relationship
+    var application: Application? = nil
+    
+    @Relationship(deleteRule: .cascade)
     var company: Company?
     
     var type: CareerType?
@@ -60,14 +64,18 @@ final class JobDescription : Codable {
     }
     
     required init(from decoder: Decoder) throws {
+        guard let context = decoder.userInfo[CodingUserInfoKey(rawValue: "modelcontext")!] as? ModelContext else {
+            fatalError()
+        }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.title = try container.decode(String.self, forKey: .title)
         self.company = try? container.decode(Company?.self, forKey: .company)
-        self.type = try? container.decode(CareerType?.self, forKey: .type)
+        self.type = try container.decode(CareerType?.self, forKey: .type)
         self.intro = try container.decode(String.self, forKey: .intro)
         self.companyIntro = try container.decode(String.self, forKey: .companyIntro)
         self.responsibilities = try container.decode(String.self, forKey: .responsibilities)
         self.complementary = try container.decode(String.self, forKey: .complementary)
+//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/EventModel.swift
+++ b/asagiri/Models/EventModel.swift
@@ -41,7 +41,9 @@ final class Event : Codable {
             fatalError()
         }
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        
         self.type = try container.decode(ApplicationStatus.self, forKey: .type)
+        
         self.updateTime = try container.decode(Date.self, forKey: .updateTime)
     }
     

--- a/asagiri/Models/EventModel.swift
+++ b/asagiri/Models/EventModel.swift
@@ -43,7 +43,6 @@ final class Event : Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.type = try container.decode(ApplicationStatus.self, forKey: .type)
         self.updateTime = try container.decode(Date.self, forKey: .updateTime)
-//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/EventModel.swift
+++ b/asagiri/Models/EventModel.swift
@@ -37,9 +37,13 @@ final class Event : Codable {
     }
     
     required init(from decoder: Decoder) throws {
+        guard let context = decoder.userInfo[CodingUserInfoKey(rawValue: "modelcontext")!] as? ModelContext else {
+            fatalError()
+        }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.type = try container.decode(ApplicationStatus.self, forKey: .type)
         self.updateTime = try container.decode(Date.self, forKey: .updateTime)
+//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/ResumeModel.swift
+++ b/asagiri/Models/ResumeModel.swift
@@ -46,7 +46,6 @@ final class Resume : Codable {
         self.content = try container.decode(String.self, forKey: .content)
         self.comments = try container.decode(String.self, forKey: .comments)
         self.createTime = try container.decode(Date.self, forKey: .createTime)
-//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Models/ResumeModel.swift
+++ b/asagiri/Models/ResumeModel.swift
@@ -39,10 +39,14 @@ final class Resume : Codable {
     }
     
     required init(from decoder: Decoder) throws {
+        guard let context = decoder.userInfo[CodingUserInfoKey(rawValue: "modelcontext")!] as? ModelContext else {
+            fatalError()
+        }
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.content = try container.decode(String.self, forKey: .content)
         self.comments = try container.decode(String.self, forKey: .comments)
         self.createTime = try container.decode(Date.self, forKey: .createTime)
+//        context.insert(self)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/asagiri/Views/ApplicationListView.swift
+++ b/asagiri/Views/ApplicationListView.swift
@@ -136,7 +136,7 @@ struct ApplicationListView: View {
                dateCreated: createDateFromString("2023-09-19T12:56:47-08:00"),
                events: [
                 Event(type: .applied, updateTime:  createDateFromString("2023-09-19T12:56:47-08:00")),
-                Event(type: .phone_screen, updateTime:  createDateFromString("2023-10-03T10:15:23-08:00"))
+                Event(type: .phoneScreen, updateTime:  createDateFromString("2023-10-03T10:15:23-08:00"))
                ])
         
         let app3 = Application(jobDescription: JobDescription(title: "Front-end developer", company: Company(name: "Company 3", website: "company.com"), type: CareerType(name: "Front-end")),

--- a/asagiri/Views/ChartWindowView.swift
+++ b/asagiri/Views/ChartWindowView.swift
@@ -114,7 +114,7 @@ func insertEventInto(paintNode node: PaintNode, events: [Event]) {
         insertOrCreatePaintEdge(node: node, label: "Pending")
     } else {
         switch events.first!.type {
-        case .not_started:
+        case .notStarted:
             var nextNode = findOrCreatePaintNode(node: node, label: "Not Started")
             insertEventInto(paintNode: nextNode, events: Array(events.dropFirst()))
         case .preparation:
@@ -126,10 +126,10 @@ func insertEventInto(paintNode node: PaintNode, events: [Event]) {
         case .oa:
             var nextNode = findOrCreatePaintNode(node: node, label: "OA")
             insertEventInto(paintNode: nextNode, events: Array(events.dropFirst()))
-        case .phone_screen:
+        case .phoneScreen:
             var nextNode = findOrCreatePaintNode(node: node, label: "Phone Screen")
             insertEventInto(paintNode: nextNode, events: Array(events.dropFirst()))
-        case .technical_test:
+        case .technicalTest:
             var nextNode = findOrCreatePaintNode(node: node, label: "Technical Test")
             insertEventInto(paintNode: nextNode, events: Array(events.dropFirst()))
         case .interview(let round):

--- a/asagiri/Views/Export+ImportView.swift
+++ b/asagiri/Views/Export+ImportView.swift
@@ -119,9 +119,6 @@ struct Export_ImportView: View {
                     decoder.keyDecodingStrategy = .convertFromSnakeCase
                     decoder.userInfo[modelContextKey] = modelContext
                     
-                    let decoded = try decoder.decode([Application].self, from: data)
-                    
-                    let results = decoded
                     
                     try modelContext.delete(model: Application.self)
                     try modelContext.delete(model: JobDescription.self)
@@ -129,10 +126,14 @@ struct Export_ImportView: View {
                     try modelContext.delete(model: Resume.self)
                     try modelContext.delete(model: CoverLetter.self)
                     
-                    results.forEach {
-                        modelContext.insert($0)
-                    }
-                 
+                    let decoded = try decoder.decode([Application].self, from: data)
+                    
+                    let results = decoded
+                    
+//                    results.forEach {
+//                        modelContext.insert($0)
+//                    }
+                    
                     importLoading = false
                     url.stopAccessingSecurityScopedResource()
                     
@@ -163,6 +164,8 @@ struct Export_ImportView: View {
             Button("Import") {
                 importAlert = true
             }
+            // Currently not available due to issues previously encountered
+//            .disabled(true)
             .alert("This operation will erase your data", isPresented: $importAlert) {
                 Button("OK", role: .destructive) {
                     importing = true

--- a/asagiri/Views/Export+ImportView.swift
+++ b/asagiri/Views/Export+ImportView.swift
@@ -38,11 +38,11 @@ enum AfterDialog {
 struct ProfileDocument : FileDocument {
     static var readableContentTypes: [UTType] { [.json] }
     
-    var applications: [Application]
+    var companies: [Company]
     var name: String
     
-    init (applications: [Application], name: String) {
-        self.applications = applications
+    init (companies: [Company], name: String) {
+        self.companies = companies
         self.name = name
     }
     
@@ -52,16 +52,16 @@ struct ProfileDocument : FileDocument {
             throw CocoaError(.fileReadCorruptFile)
         }
         
-        let applications = try JSONDecoder().decode([Application].self, from: data)
+        let companies = try JSONDecoder().decode([Company].self, from: data)
         
-        self.applications = applications
+        self.companies = companies
         self.name = configuration.file.filename ?? "profile"
     }
     
     func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
         let jsonEncoder = JSONEncoder()
         jsonEncoder.outputFormatting = .prettyPrinted
-        let encoded: Data = try! jsonEncoder.encode(applications)
+        let encoded: Data = try! jsonEncoder.encode(companies)
         
         let fileWrapper = FileWrapper(regularFileWithContents: encoded)
         fileWrapper.filename = self.name
@@ -91,7 +91,7 @@ struct Export_ImportView: View {
     
     @State private var afterDialogReason: AfterDialog = .none
     
-    @Query var applications: [Application]
+    @Query var companies: [Company]
     
     @State var _exportText: ProfileDocument? = nil
     
@@ -102,7 +102,7 @@ struct Export_ImportView: View {
     
     func exportToFile() {
         
-        _exportText = ProfileDocument(applications: applications, name: "asagiri-profile")
+        _exportText = ProfileDocument(companies: companies, name: "asagiri-profile")
         exporting = true
     }
     
@@ -126,7 +126,7 @@ struct Export_ImportView: View {
                     try modelContext.delete(model: Resume.self)
                     try modelContext.delete(model: CoverLetter.self)
                     
-                    let decoded = try decoder.decode([Application].self, from: data)
+                    let decoded = try decoder.decode([Company].self, from: data)
                     
                     let results = decoded
                     

--- a/asagiri/Views/Export+ImportView.swift
+++ b/asagiri/Views/Export+ImportView.swift
@@ -130,10 +130,6 @@ struct Export_ImportView: View {
                     
                     let results = decoded
                     
-//                    results.forEach {
-//                        modelContext.insert($0)
-//                    }
-                    
                     importLoading = false
                     url.stopAccessingSecurityScopedResource()
                     
@@ -164,8 +160,6 @@ struct Export_ImportView: View {
             Button("Import") {
                 importAlert = true
             }
-            // Currently not available due to issues previously encountered
-//            .disabled(true)
             .alert("This operation will erase your data", isPresented: $importAlert) {
                 Button("OK", role: .destructive) {
                     importing = true

--- a/asagiri/Views/Parts/ApplicationCard.swift
+++ b/asagiri/Views/Parts/ApplicationCard.swift
@@ -153,7 +153,7 @@ struct ApplicationCard: View {
                         .font(.footnote)
                     }
                     
-                    DatePicker(selection: $updateDate, in: app.events.last!.updateTime...Date.now, displayedComponents: .date) {
+                    DatePicker(selection: $updateDate, in: app.events.sorted(by: { $0.updateTime < $1.updateTime }).last!.updateTime...Date.now, displayedComponents: .date) {
                         Text("Update date")
                             .font(.callout)
                     }


### PR DESCRIPTION
This PR repaired the previously broken export/import features. Exported JSON files should be decoded back into application without error. The enum decode was also fixed as the decoding strategy should be identical across enum and class properties naming convention.

A special process was implemented to de-duplicate decoded `CareerType` entries and rearrange them properly.

Several other minor fixes were performed.